### PR TITLE
Updated TargetFramework from netstandard2.0 to netcoreapp2.1

### DIFF
--- a/dotnet/ServerlessMicroservices.FunctionApp.Drivers/ServerlessMicroservices.FunctionApp.Drivers.csproj
+++ b/dotnet/ServerlessMicroservices.FunctionApp.Drivers/ServerlessMicroservices.FunctionApp.Drivers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/dotnet/ServerlessMicroservices.FunctionApp.Orchestrators/ServerlessMicroservices.FunctionApp.Orchestrators.csproj
+++ b/dotnet/ServerlessMicroservices.FunctionApp.Orchestrators/ServerlessMicroservices.FunctionApp.Orchestrators.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/dotnet/ServerlessMicroservices.FunctionApp.Passengers/ServerlessMicroservices.FunctionApp.Passengers.csproj
+++ b/dotnet/ServerlessMicroservices.FunctionApp.Passengers/ServerlessMicroservices.FunctionApp.Passengers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/dotnet/ServerlessMicroservices.FunctionApp.Trips/ServerlessMicroservices.FunctionApp.Trips.csproj
+++ b/dotnet/ServerlessMicroservices.FunctionApp.Trips/ServerlessMicroservices.FunctionApp.Trips.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/dotnet/ServerlessMicroservices.Models/ServerlessMicroservices.Models.csproj
+++ b/dotnet/ServerlessMicroservices.Models/ServerlessMicroservices.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/ServerlessMicroservices.Shared/ServerlessMicroservices.Shared.csproj
+++ b/dotnet/ServerlessMicroservices.Shared/ServerlessMicroservices.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Updated the TargetFramework from netstandard2.0 to netcoreapp2.1 to make the Azure functions run in the new Runtime stack options available in the Azure Functions app. The runtime stack now has .NET core as the .NET related runtime stack. I've tried publishing the initial code version of the Azure functions from Visual Studio 2019 and I've encountered an error related to runtime mismatch thus the change in the TargetFramework.

To test the failure try the following:
1. Create an Azure function app named ServerlessMicroservices.FunctionApp.Drivers in Azure choosing .Net Core as Runtime stack.
2. Open ServerlessMicroservices.FunctionApp.Drivers in Visual Studio 2019.
3. Publish ServerlessMicroservices.FunctionApp.Drivers to Azure.
4. Error to publish Azure Function from Visual Studio 2019 will be encountered and log in the User temp folder.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* After pulling the latest version of the Azure functions, publishing those using Visual Studio 2019 must be successful.

## Other Information
<!-- Add any other helpful information that may be needed here. -->