### PR TITLE
Improve security on templates. 

### DIFF
--- a/bicep/modules/apim.bicep
+++ b/bicep/modules/apim.bicep
@@ -1,6 +1,7 @@
 @description('API Management DB account name')
 param apimName string
 param appInsightsName string
+@secure()
 param appInsightsInstrumentationKey string
 param resourceTags object
 
@@ -22,7 +23,7 @@ var location = resourceGroup().location
 var publisherEmail = 'email@contoso.com'
 var publisherName = 'Company Name'
 
-resource apiManagement 'Microsoft.ApiManagement/service@2021-01-01-preview' = {
+resource apiManagement 'Microsoft.ApiManagement/service@2021-08-01' = {
   name: apimName
   location: location
   tags: resourceTags
@@ -33,6 +34,23 @@ resource apiManagement 'Microsoft.ApiManagement/service@2021-01-01-preview' = {
   properties: {
     publisherEmail: publisherEmail
     publisherName: publisherName
+    customProperties: {
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Ssl30': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2': 'True'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TripleDes168': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_RSA_WITH_AES_128_CBC_SHA': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_RSA_WITH_AES_256_CBC_SHA': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_RSA_WITH_AES_128_CBC_SHA256': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_RSA_WITH_AES_256_CBC_SHA256': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_RSA_WITH_AES_128_GCM_SHA256': 'False'
+    }
   }
   identity: {
     type: 'SystemAssigned'

--- a/bicep/modules/cosmosdb.bicep
+++ b/bicep/modules/cosmosdb.bicep
@@ -16,7 +16,7 @@ var containerNames = [
   'archiver'
 ]
 
-resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' = {
+resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
   name: toLower(accountName)
   kind: 'GlobalDocumentDB'
   location: location
@@ -38,7 +38,8 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' = {
           backupIntervalInMinutes: 240
           backupRetentionIntervalInHours: 8
       }
-  }
+    }
+    minimalTlsVersion: 'Tls12'
   }
 }
 

--- a/bicep/modules/functions.bicep
+++ b/bicep/modules/functions.bicep
@@ -4,6 +4,7 @@ param functionApps array
 param appServicePlanName string
 param location string = resourceGroup().location
 param staticWebAppURL string
+@secure()
 param appInsightsInstrumentationKey string
 param resourceTags object
 
@@ -20,6 +21,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   kind: 'StorageV2'
   properties: {
     supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
     encryption: {
       services: {
         file: {
@@ -48,7 +50,7 @@ resource plan 'Microsoft.Web/serverFarms@2020-06-01' = {
   properties: {}
 }
 
-resource functionApp 'Microsoft.Web/sites@2020-06-01' = [for functionApp in functionApps :{
+resource functionApp 'Microsoft.Web/sites@2023-12-01' = [for functionApp in functionApps :{
   name: '${functionAppPrefix}${functionApp}'
   location: location
   kind: 'functionapp'
@@ -86,6 +88,7 @@ resource functionApp 'Microsoft.Web/sites@2020-06-01' = [for functionApp in func
           staticWebAppURL
         ]
       }
+      minTlsVersion: '1.2'
     }
     httpsOnly: true
   }

--- a/bicep/modules/sqldb.bicep
+++ b/bicep/modules/sqldb.bicep
@@ -6,7 +6,7 @@ param administratorLogin string
 param administratorPassword string
 param resourceTags object
 
-resource sqlServer 'Microsoft.Sql/servers@2021-05-01-preview' = {
+resource sqlServer 'Microsoft.Sql/servers@2022-11-01-preview' = {
   name: sqlServerName
   location: location
   tags: resourceTags
@@ -14,6 +14,7 @@ resource sqlServer 'Microsoft.Sql/servers@2021-05-01-preview' = {
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorPassword
     version: '12.0'
+    minimalTlsVersion: '1.2'
   }
   dependsOn: []
 }
@@ -32,5 +33,20 @@ resource servers_rideshare_server_name_databases_Rideshare_name 'Microsoft.Sql/s
     maxSizeBytes: 268435456000
     catalogCollation: 'SQL_Latin1_General_CP1_CI_AS'
     zoneRedundant: false
+  }
+}
+
+resource sqlAuditSettings 'Microsoft.Sql/servers/auditingSettings@2022-08-01-preview' = {
+  name: 'default'
+  parent: sqlServer
+  properties: {
+    isAzureMonitorTargetEnabled: true
+    state: 'Enabled'
+    retentionDays: 7
+    auditActionsAndGroups: [
+      'SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP'
+      'FAILED_DATABASE_AUTHENTICATION_GROUP'
+      'BATCH_COMPLETED_GROUP'
+    ]
   }
 }


### PR DESCRIPTION
- Don't log app insights instrumentation keys. 
- Set minimum TLS versions
- Set APIM to deny insecure protocols
- Use SQL auditing